### PR TITLE
Venath/feature/learning plans service

### DIFF
--- a/backend/src/main/java/com/zos/controller/LearningPlanController.java
+++ b/backend/src/main/java/com/zos/controller/LearningPlanController.java
@@ -1,0 +1,146 @@
+package com.zos.controller;
+
+import com.zos.exception.LearningPlanException;
+import com.zos.exception.ResourceException;
+import com.zos.exception.TopicException;
+import com.zos.exception.UserException;
+import com.zos.model.LearningPlan;
+import com.zos.model.Resource;
+import com.zos.model.Topic;
+import com.zos.model.User;
+import com.zos.response.MessageResponse;
+import com.zos.services.LearningPlanService;
+import com.zos.services.UserService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/learning_plan")
+public class LearningPlanController {
+
+    @Autowired
+    private LearningPlanService learningPlanService;
+
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/")
+    public ResponseEntity<LearningPlan> createLearningPlan(@Valid
+            @RequestBody LearningPlan learningPlan,
+            @RequestHeader("Authorization") String token) throws UserException {
+
+        User user = userService.findUserProfile(token);
+        LearningPlan createdPlan = learningPlanService.createLearningPlan(learningPlan, user.getId());
+        return new ResponseEntity<>(createdPlan, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{planId}")
+    public ResponseEntity<LearningPlan> updateLearningPlan(
+            @PathVariable Long planId,
+            @RequestBody LearningPlan learningPlan,
+            @RequestHeader("Authorization") String token) throws UserException, LearningPlanException {
+
+        User user = userService.findUserProfile(token);
+        learningPlan.setId(planId);
+        LearningPlan updatedPlan = learningPlanService.updateLearningPlan(learningPlan, user.getId());
+        return new ResponseEntity<>(updatedPlan, HttpStatus.OK);
+    }
+
+    @GetMapping("/{planId}")
+    public ResponseEntity<LearningPlan> getLearningPlan(
+            @PathVariable Long planId) throws LearningPlanException {
+
+        LearningPlan plan = learningPlanService.getLearningPlanById(planId);
+        return new ResponseEntity<>(plan, HttpStatus.OK);
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<List<LearningPlan>> getUserLearningPlans(
+            @RequestHeader("Authorization") String token) throws UserException {
+
+        User user = userService.findUserProfile(token);
+        List<LearningPlan> plans = learningPlanService.getLearningPlansByUserId(user.getId());
+        return new ResponseEntity<>(plans, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<MessageResponse> deleteLearningPlan(
+            @PathVariable Long planId,
+            @RequestHeader("Authorization") String token) throws UserException, LearningPlanException {
+
+        User user = userService.findUserProfile(token);
+        learningPlanService.deleteLearningPlan(planId, user.getId());
+        return new ResponseEntity<>(new MessageResponse("Learning plan deleted successfully"), HttpStatus.OK);
+    }
+
+    @PostMapping("/{planId}/topics")
+    public ResponseEntity<Topic> addTopicToPlan(
+            @PathVariable Long planId,
+            @RequestBody Topic topic,
+            @RequestHeader("Authorization") String token) throws UserException, LearningPlanException {
+
+        User user = userService.findUserProfile(token);
+        Topic createdTopic = learningPlanService.addTopicToPlan(planId, topic, user.getId());
+        return new ResponseEntity<>(createdTopic, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/topics/{topicId}")
+    public ResponseEntity<Topic> updateTopic(
+            @PathVariable Long topicId,
+            @RequestBody Topic topic,
+            @RequestHeader("Authorization") String token) throws UserException, TopicException {
+
+        User user = userService.findUserProfile(token);
+        topic.setId(topicId);
+        Topic updatedTopic = learningPlanService.updateTopic(topicId, topic, user.getId());
+        return new ResponseEntity<>(updatedTopic, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/topics/{topicId}")
+    public ResponseEntity<MessageResponse> deleteTopic(
+            @PathVariable Long topicId,
+            @RequestHeader("Authorization") String token) throws UserException, TopicException {
+
+        User user = userService.findUserProfile(token);
+        learningPlanService.deleteTopic(topicId, user.getId());
+        return new ResponseEntity<>(new MessageResponse("Topic deleted successfully"), HttpStatus.OK);
+    }
+
+    @PostMapping("/topics/{topicId}/resources")
+    public ResponseEntity<Resource> addResourceToTopic(
+            @PathVariable Long topicId,
+            @RequestBody Resource resource,
+            @RequestHeader("Authorization") String token) throws UserException, TopicException {
+
+        User user = userService.findUserProfile(token);
+        Resource createdResource = learningPlanService.addResourceToTopic(topicId, resource, user.getId());
+        return new ResponseEntity<>(createdResource, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/resources/{resourceId}")
+    public ResponseEntity<Resource> updateResource(
+            @PathVariable Long resourceId,
+            @RequestBody Resource resource,
+            @RequestHeader("Authorization") String token) throws UserException, ResourceException {
+
+        User user = userService.findUserProfile(token);
+        resource.setId(resourceId);
+        Resource updatedResource = learningPlanService.updateResource(resourceId, resource, user.getId());
+        return new ResponseEntity<>(updatedResource, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/resources/{resourceId}")
+    public ResponseEntity<MessageResponse> deleteResource(
+            @PathVariable Long resourceId,
+            @RequestHeader("Authorization") String token) throws UserException, ResourceException {
+
+        User user = userService.findUserProfile(token);
+        learningPlanService.deleteResource(resourceId, user.getId());
+        return new ResponseEntity<>(new MessageResponse("Resource deleted successfully"), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/zos/controller/LearningProgressUpdateController.java
+++ b/backend/src/main/java/com/zos/controller/LearningProgressUpdateController.java
@@ -1,0 +1,63 @@
+package com.zos.controller;
+
+import com.zos.exception.UserException;
+import com.zos.model.LearningProgressUpdate;
+import com.zos.model.User;
+import com.zos.response.MessageResponse;
+import com.zos.services.LearningProgressUpdateService;
+import com.zos.services.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/progress")
+public class LearningProgressUpdateController {
+
+    @Autowired
+    private LearningProgressUpdateService updateService;
+
+    @Autowired
+    private UserService userService;
+
+    @PostMapping("/")
+    public ResponseEntity<LearningProgressUpdate> create(
+            @RequestBody LearningProgressUpdate update,
+            @RequestHeader("Authorization") String token
+    ) throws UserException {
+        User user = userService.findUserProfile(token);
+        LearningProgressUpdate created = updateService.createProgressUpdate(update, user.getId());
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/user")
+    public List<LearningProgressUpdate> getUserUpdates(
+            @RequestHeader("Authorization") String token
+    ) throws UserException {
+        User user = userService.findUserProfile(token);
+        return updateService.getUserProgressUpdates(user.getId());
+    }
+
+    @PutMapping("/{id}")
+    public LearningProgressUpdate update(
+            @PathVariable Long id,
+            @RequestBody LearningProgressUpdate update,
+            @RequestHeader("Authorization") String token
+    ) throws UserException {
+        User user = userService.findUserProfile(token);
+        return updateService.updateProgressUpdate(id, update, user.getId());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<MessageResponse> delete(
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String token
+    ) throws UserException {
+        User user = userService.findUserProfile(token);
+        updateService.deleteProgressUpdate(id, user.getId());
+        return ResponseEntity.ok(new MessageResponse("Deleted successfully"));
+    }
+}

--- a/backend/src/main/java/com/zos/exception/LearningPlanException.java
+++ b/backend/src/main/java/com/zos/exception/LearningPlanException.java
@@ -1,0 +1,9 @@
+package com.zos.exception;
+
+public class LearningPlanException extends Exception {
+    public LearningPlanException(String message) {
+        super(message);
+
+    }
+
+}

--- a/backend/src/main/java/com/zos/model/LearningPlan.java
+++ b/backend/src/main/java/com/zos/model/LearningPlan.java
@@ -1,0 +1,98 @@
+package com.zos.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class LearningPlan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    @JsonBackReference
+    private User user;
+
+    @OneToMany(mappedBy = "learningPlan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private List<Topic> topics = new ArrayList<>();
+
+    public LearningPlan() {}
+
+    public LearningPlan(Long id, String title, String description, LocalDateTime createdAt, LocalDateTime updatedAt, User user, List<Topic> topics) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.user = user;
+        this.topics = topics;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public List<Topic> getTopics() {
+        return topics;
+    }
+
+    public void setTopics(List<Topic> topics) {
+        this.topics = topics;
+    }
+}

--- a/backend/src/main/java/com/zos/model/LearningProgressUpdate.java
+++ b/backend/src/main/java/com/zos/model/LearningProgressUpdate.java
@@ -1,0 +1,73 @@
+package com.zos.model;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class LearningProgressUpdate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    @JsonBackReference
+    private User user;
+
+    public LearningProgressUpdate() {}
+
+    public LearningProgressUpdate(Long id, String title, String content, LocalDateTime createdAt, User user) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.user = user;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/backend/src/main/java/com/zos/repository/LearningPlanRepository.java
+++ b/backend/src/main/java/com/zos/repository/LearningPlanRepository.java
@@ -1,0 +1,16 @@
+package com.zos.repository;
+
+import com.zos.model.LearningPlan;
+import com.zos.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface LearningPlanRepository extends JpaRepository<LearningPlan, Long> {
+    List<LearningPlan> findByUser(User user);
+
+    @Query("SELECT lp FROM LearningPlan lp WHERE lp.user.id = :userId")
+    List<LearningPlan> findByUserId(@Param("userId") Integer userId);
+}

--- a/backend/src/main/java/com/zos/repository/LearningProgressUpdateRepository.java
+++ b/backend/src/main/java/com/zos/repository/LearningProgressUpdateRepository.java
@@ -1,0 +1,11 @@
+package com.zos.repository;
+
+import com.zos.model.LearningProgressUpdate;
+import com.zos.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LearningProgressUpdateRepository extends JpaRepository<LearningProgressUpdate, Long> {
+    List<LearningProgressUpdate> findByUser(User user);
+}

--- a/backend/src/main/java/com/zos/services/LearningPlanService.java
+++ b/backend/src/main/java/com/zos/services/LearningPlanService.java
@@ -1,0 +1,27 @@
+package com.zos.services;
+
+import com.zos.exception.LearningPlanException;
+import com.zos.exception.ResourceException;
+import com.zos.exception.TopicException;
+import com.zos.exception.UserException;
+import com.zos.model.LearningPlan;
+import com.zos.model.Resource;
+import com.zos.model.Topic;
+
+import java.util.List;
+
+public interface LearningPlanService {
+    LearningPlan createLearningPlan(LearningPlan learningPlan, Integer userId) throws UserException;
+    LearningPlan updateLearningPlan(LearningPlan learningPlan, Integer userId) throws UserException, LearningPlanException;
+    LearningPlan getLearningPlanById(Long planId) throws LearningPlanException;
+    List<LearningPlan> getLearningPlansByUserId(Integer userId) throws UserException;
+    void deleteLearningPlan(Long planId, Integer userId) throws LearningPlanException, UserException;
+
+    Topic addTopicToPlan(Long planId, Topic topic, Integer userId) throws LearningPlanException, UserException;
+    Topic updateTopic(Long topicId, Topic topic, Integer userId) throws TopicException, UserException;
+    void deleteTopic(Long topicId, Integer userId) throws TopicException, UserException;
+
+    Resource addResourceToTopic(Long topicId, Resource resource, Integer userId) throws TopicException, UserException;
+    Resource updateResource(Long resourceId, Resource resource, Integer userId) throws ResourceException, UserException;
+    void deleteResource(Long resourceId, Integer userId) throws ResourceException, UserException;
+}

--- a/backend/src/main/java/com/zos/services/LearningPlanServiceImpl.java
+++ b/backend/src/main/java/com/zos/services/LearningPlanServiceImpl.java
@@ -1,0 +1,162 @@
+package com.zos.services;
+
+import com.zos.exception.LearningPlanException;
+import com.zos.exception.ResourceException;
+import com.zos.exception.TopicException;
+import com.zos.exception.UserException;
+import com.zos.model.LearningPlan;
+import com.zos.model.Resource;
+import com.zos.model.Topic;
+import com.zos.model.User;
+import com.zos.repository.LearningPlanRepository;
+import com.zos.repository.ResourceRepository;
+import com.zos.repository.TopicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class LearningPlanServiceImpl implements LearningPlanService {
+
+    @Autowired
+    private LearningPlanRepository learningPlanRepository;
+
+    @Autowired
+    private TopicRepository topicRepository;
+
+    @Autowired
+    private ResourceRepository resourceRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Override
+    public LearningPlan createLearningPlan(LearningPlan learningPlan, Integer userId) throws UserException {
+        User user = userService.findUserById(userId);
+        learningPlan.setUser(user);
+        learningPlan.setCreatedAt(LocalDateTime.now());
+        learningPlan.setUpdatedAt(LocalDateTime.now());
+        LearningPlan savedPlan = learningPlanRepository.save(learningPlan);
+        return savedPlan;
+    }
+
+    @Override
+    public LearningPlan updateLearningPlan(LearningPlan learningPlan, Integer userId) throws LearningPlanException, UserException {
+        LearningPlan existingPlan = getLearningPlanById(learningPlan.getId());
+
+        if (!existingPlan.getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to update this plan");
+        }
+
+        existingPlan.setTitle(learningPlan.getTitle());
+        existingPlan.setDescription(learningPlan.getDescription());
+        existingPlan.setUpdatedAt(LocalDateTime.now());
+
+        return learningPlanRepository.save(existingPlan);
+    }
+
+    @Override
+    public LearningPlan getLearningPlanById(Long planId) throws LearningPlanException {
+        return learningPlanRepository.findById(planId)
+                .orElseThrow(() -> new LearningPlanException("Learning plan not found with id: " + planId));
+    }
+
+    @Override
+    public List<LearningPlan> getLearningPlansByUserId(Integer userId) throws UserException {
+        return learningPlanRepository.findByUserId(userId);
+    }
+
+    @Override
+    public void deleteLearningPlan(Long planId, Integer userId) throws LearningPlanException, UserException {
+        LearningPlan plan = getLearningPlanById(planId);
+
+        if (!plan.getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to delete this plan");
+        }
+
+        learningPlanRepository.delete(plan);
+    }
+
+    @Override
+    public Topic addTopicToPlan(Long planId, Topic topic, Integer userId) throws LearningPlanException, UserException {
+        LearningPlan plan = getLearningPlanById(planId);
+
+        if (!plan.getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to add topics to this plan");
+        }
+
+        topic.setLearningPlan(plan);
+        return topicRepository.save(topic);
+    }
+
+    @Override
+    public Topic updateTopic(Long topicId, Topic topic, Integer userId) throws TopicException, UserException {
+        Topic existingTopic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new TopicException("Topic not found with id: " + topicId));
+
+        if (!existingTopic.getLearningPlan().getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to update this topic");
+        }
+
+        existingTopic.setTitle(topic.getTitle());
+        existingTopic.setDescription(topic.getDescription());
+        existingTopic.setCompleted(topic.isCompleted());
+        existingTopic.setTargetCompletionDate(topic.getTargetCompletionDate());
+
+        return topicRepository.save(existingTopic);
+    }
+
+    @Override
+    public void deleteTopic(Long topicId, Integer userId) throws TopicException, UserException {
+        Topic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new TopicException("Topic not found with id: " + topicId));
+
+        if (!topic.getLearningPlan().getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to delete this topic");
+        }
+
+        topicRepository.delete(topic);
+    }
+
+    @Override
+    public Resource addResourceToTopic(Long topicId, Resource resource, Integer userId) throws TopicException, UserException {
+        Topic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new TopicException("Topic not found with id: " + topicId));
+
+        if (!topic.getLearningPlan().getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to add resources to this topic");
+        }
+
+        resource.setTopic(topic);
+        return resourceRepository.save(resource);
+    }
+
+    @Override
+    public Resource updateResource(Long resourceId, Resource resource, Integer userId) throws ResourceException, UserException {
+        Resource existingResource = resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new ResourceException("Resource not found with id: " + resourceId));
+
+        if (!existingResource.getTopic().getLearningPlan().getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to update this resource");
+        }
+
+        existingResource.setUrl(resource.getUrl());
+        existingResource.setDescription(resource.getDescription());
+
+        return resourceRepository.save(existingResource);
+    }
+
+    @Override
+    public void deleteResource(Long resourceId, Integer userId) throws ResourceException, UserException {
+        Resource resource = resourceRepository.findById(resourceId)
+                .orElseThrow(() -> new ResourceException("Resource not found with id: " + resourceId));
+
+        if (!resource.getTopic().getLearningPlan().getUser().getId().equals(userId)) {
+            throw new UserException("You don't have permission to delete this resource");
+        }
+
+        resourceRepository.delete(resource);
+    }
+}

--- a/backend/src/main/java/com/zos/services/LearningProgressUpdateService.java
+++ b/backend/src/main/java/com/zos/services/LearningProgressUpdateService.java
@@ -1,0 +1,17 @@
+package com.zos.services;
+
+import com.zos.exception.UserException;
+import com.zos.model.LearningProgressUpdate;
+
+import java.util.List;
+
+public interface LearningProgressUpdateService {
+
+    LearningProgressUpdate createProgressUpdate(LearningProgressUpdate update, Integer userId) throws UserException;
+
+    LearningProgressUpdate updateProgressUpdate(Long id, LearningProgressUpdate update, Integer userId) throws UserException;
+
+    void deleteProgressUpdate(Long id, Integer userId) throws UserException;
+
+    List<LearningProgressUpdate> getUserProgressUpdates(Integer userId) throws UserException;
+}

--- a/backend/src/main/java/com/zos/services/LearningProgressUpdateServiceImpl.java
+++ b/backend/src/main/java/com/zos/services/LearningProgressUpdateServiceImpl.java
@@ -1,0 +1,52 @@
+package com.zos.services;
+
+import com.zos.exception.UserException;
+import com.zos.model.LearningProgressUpdate;
+import com.zos.model.User;
+import com.zos.repository.LearningProgressUpdateRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class LearningProgressUpdateServiceImpl implements LearningProgressUpdateService {
+
+    @Autowired
+    private LearningProgressUpdateRepository updateRepository;
+    @Autowired private UserService userService;
+
+    @Override
+    public LearningProgressUpdate createProgressUpdate(LearningProgressUpdate update, Integer userId) throws UserException {
+        User user = userService.findUserById(userId);
+        update.setUser(user);
+        update.setCreatedAt(LocalDateTime.now());
+        return updateRepository.save(update);
+    }
+
+    @Override
+    public LearningProgressUpdate updateProgressUpdate(Long id, LearningProgressUpdate update, Integer userId) throws UserException {
+        LearningProgressUpdate existing = updateRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Update not found"));
+        if (!existing.getUser().getId().equals(userId)) throw new RuntimeException("Unauthorized");
+        existing.setTitle(update.getTitle());
+        existing.setContent(update.getContent());
+        return updateRepository.save(existing);
+    }
+
+    @Override
+    public void deleteProgressUpdate(Long id, Integer userId) throws UserException {
+        LearningProgressUpdate existing = updateRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Update not found"));
+        if (!existing.getUser().getId().equals(userId)) throw new RuntimeException("Unauthorized");
+        updateRepository.delete(existing);
+    }
+
+    @Override
+    public List<LearningProgressUpdate> getUserProgressUpdates(Integer userId) throws UserException {
+        User user = userService.findUserById(userId);
+        return updateRepository.findByUser(user);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new feature for managing learning plans and progress updates in the backend. It includes the implementation of controllers, services, models, repositories, and custom exceptions. The changes enable users to create, update, retrieve, and delete learning plans, topics, resources, and progress updates, with appropriate authorization checks.

### Learning Plan Management:
* Added `LearningPlanController` to handle REST API endpoints for creating, updating, retrieving, and deleting learning plans, topics, and resources. Includes endpoints for user-specific operations.
* Implemented `LearningPlanService` and `LearningPlanServiceImpl` to handle business logic for managing learning plans, topics, and resources, with user authorization checks. [[1]](diffhunk://#diff-2e353b538fe6c70c5274afda856c8a4069f9afbbaf88d44efda2ff2f8b26abbcR1-R27) [[2]](diffhunk://#diff-201123b50c0387759c370b001b6f0b3fa9e3dd6e0993587437b1c49a7ca4b773R1-R162)
* Created `LearningPlan` model with JPA annotations for persistence, including relationships with `User` and `Topic` entities.
* Added `LearningPlanRepository` for database operations related to learning plans, including user-specific queries.

### Learning Progress Updates:
* Added `LearningProgressUpdateController` to handle REST API endpoints for creating, updating, retrieving, and deleting progress updates.
* Implemented `LearningProgressUpdateService` interface and its methods for managing progress updates.
* Created `LearningProgressUpdate` model with JPA annotations for persistence, including a relationship with the `User` entity.
* Added `LearningProgressUpdateRepository` for database operations related to progress updates.

### Exception Handling:
* Introduced `LearningPlanException` for handling errors specific to learning plan operations.