### PR TITLE
Venath/feature/reel uploading and posting

### DIFF
--- a/backend/src/main/java/com/zos/controller/ReelController.java
+++ b/backend/src/main/java/com/zos/controller/ReelController.java
@@ -1,0 +1,86 @@
+package com.zos.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowire;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestHeader;
+//import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zos.dto.UserDto;
+import com.zos.exception.PostException;
+import com.zos.exception.UserException;
+import com.zos.model.Post;
+import com.zos.model.Reels;
+import com.zos.model.User;
+import com.zos.response.MessageResponse;
+import com.zos.services.ReelService;
+import com.zos.services.UserService;
+
+@RestController
+@RequestMapping("/api/reels")
+public class ReelController {
+
+    @Autowired
+    private ReelService reelService;
+
+    @Autowired
+    private UserService userService;
+
+
+    @PostMapping("/create")
+    public ResponseEntity<Reels> createPostHandler(@RequestBody Reels reel, @RequestHeader("Authorization") String token) throws UserException {
+
+
+        User user = userService.findUserProfile(token);
+
+        UserDto userDto = new UserDto();
+
+        userDto.setEmail(user.getEmail());
+        userDto.setUsername(user.getUsername());
+        userDto.setId(user.getId());
+        userDto.setName(user.getName());
+        userDto.setUserImage(user.getImage());
+
+        reel.setUser(userDto);
+
+        System.out.println("create reel------" + reel.getVideo());
+
+        Reels createdReel = reelService.createReels(reel);
+
+
+        return new ResponseEntity<Reels>(createdReel, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<Reels>> getAllReelHandler() {
+
+        System.out.println("get all reel -------- ");
+        List<Reels> reels = reelService.getAllReels();
+
+        return new ResponseEntity<List<Reels>>(reels, HttpStatus.ACCEPTED);
+    }
+
+    @DeleteMapping("/delete/{reelId}")
+    public ResponseEntity<MessageResponse> deleteReelHandler(@PathVariable Integer reelId) throws PostException {
+
+        reelService.deleteReels(reelId);
+
+        MessageResponse res = new MessageResponse("Reel Deleted Succefully");
+
+        return new ResponseEntity<MessageResponse>(res, HttpStatus.OK);
+
+    }
+
+}

--- a/backend/src/main/java/com/zos/exception/ReeelException copy.java
+++ b/backend/src/main/java/com/zos/exception/ReeelException copy.java
@@ -1,0 +1,10 @@
+package com.zos.exception;
+
+public class ReeelException extends Exception {
+	
+	public ReeelException(String message) {
+		super(message);
+		
+	}
+
+}

--- a/backend/src/main/java/com/zos/model/Reels.java
+++ b/backend/src/main/java/com/zos/model/Reels.java
@@ -1,0 +1,77 @@
+package com.zos.model;
+
+import jakarta.persistence.Id;
+
+import com.zos.dto.UserDto;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+
+@Entity
+public class Reels {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String caption;
+
+    private String video;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "user_id"))
+    @AttributeOverride(name = "email", column = @Column(name = "user_email"))
+    @AttributeOverride(name = "username", column = @Column(name = "user_username"))
+    private UserDto user;
+
+    public Reels() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public Reels(Integer id, String caption, String video, UserDto user) {
+        super();
+        this.id = id;
+        this.caption = caption;
+        this.video = video;
+        this.user = user;
+    }
+
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getCaption() {
+        return caption;
+    }
+
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
+
+    public String getVideo() {
+        return video;
+    }
+
+    public void setVideo(String video) {
+        this.video = video;
+    }
+
+    public UserDto getUser() {
+        return user;
+    }
+
+    public void setUser(UserDto user) {
+        this.user = user;
+    }
+
+
+}

--- a/backend/src/main/java/com/zos/repository/ReelRepository.java
+++ b/backend/src/main/java/com/zos/repository/ReelRepository.java
@@ -1,0 +1,8 @@
+package com.zos.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.zos.model.Reels;
+
+public interface ReelRepository extends JpaRepository<Reels, Integer>{
+}

--- a/backend/src/main/java/com/zos/services/ReelService.java
+++ b/backend/src/main/java/com/zos/services/ReelService.java
@@ -1,0 +1,17 @@
+package com.zos.services;
+
+import java.util.List;
+
+import com.zos.model.Reels;
+
+public interface ReelService {
+	
+	public Reels createReels(Reels reel);
+	
+	public void deleteReels(Integer reelId);
+	
+	public void editReels(Reels reel);
+	
+	public List<Reels> getAllReels();
+
+}

--- a/backend/src/main/java/com/zos/services/ReelServiceImplementation.java
+++ b/backend/src/main/java/com/zos/services/ReelServiceImplementation.java
@@ -1,0 +1,43 @@
+package com.zos.services;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.zos.model.Reels;
+import com.zos.repository.ReelRepository;
+
+@Service
+public class ReelServiceImplementation implements ReelService {
+	
+	@Autowired
+	private ReelRepository reelRepository;
+
+	@Override
+	public Reels createReels(Reels reel) {
+		
+		return reelRepository.save(reel);
+	}
+	
+
+	@Override
+	public void deleteReels(Integer reelId) {
+		reelRepository.deleteById(reelId);
+		
+	}
+
+	@Override
+	public void editReels(Reels reel) {
+		reelRepository.save(reel);
+		
+	}
+
+
+	@Override
+	public List<Reels> getAllReels() {
+		List<Reels> reels=reelRepository.findAll();
+		return reels;
+	}
+
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing "Reels" in the application. It includes the implementation of a `ReelController`, a `Reels` model, a repository interface, a service layer, and a custom exception class. Below are the key changes grouped by their themes:

### Controller and API Endpoints
* Added `ReelController` to handle HTTP requests for creating, retrieving, and deleting reels. It includes endpoints for creating a reel (`/create`), retrieving all reels (`/`), and deleting a reel by ID (`/delete/{reelId}`).

### Data Model
* Introduced the `Reels` entity class with fields for `id`, `caption`, `video`, and an embedded `UserDto` to associate reels with users. The class includes JPA annotations for database mapping.

### Repository
* Created `ReelRepository`, a JPA repository interface for performing CRUD operations on the `Reels` entity.

### Service Layer
* Added `ReelService` interface and its implementation, `ReelServiceImplementation`, to encapsulate business logic for managing reels. This includes methods for creating, editing, deleting, and retrieving reels. [[1]](diffhunk://#diff-ef040720b31bedd65f405f3128b92a89d81093dc50cce1a8c51a782b9e86857fR1-R17) [[2]](diffhunk://#diff-4c6015cd9a884165220464199368ecc7d563b1147665728222aa15f1ac552761R1-R43)

### Exception Handling
* Added a custom exception class, `ReeelException`, to handle reel-specific errors.